### PR TITLE
Add Docker build and publish workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Docker Build and Publish
+
+on:
+  workflow_dispatch: # Enables a manual trigger from GitHub Actions UI
+  release:
+    types:
+      - published # Automatically triggers on releases
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Convert owner name to lower case
+      run: |
+        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      env:
+        OWNER: '${{ github.repository_owner }}'
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build & push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: docker/Dockerfile 
+        push: true
+        # Always push latest
+        # Use the release tag name if building on a release, otherwise fall back to manual
+        # 
+        # registry name must be lower case
+        tags: |
+          ghcr.io/${{ env.OWNER_LC }}/re-command:latest
+          ghcr.io/${{ env.OWNER_LC }}/re-command:${{ github.event.release.tag_name || 'manual' }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build and publish Docker images to GitHub Container Registry (GHCR).

The workflow:
- Triggers on new releases and manually via workflow_dispatch.
- Builds and pushes the image.
- Tags images as 'latest' and with the release version.

This simplifies deployment by allowing users to pull prebuilt images from GHCR instead of building locally.